### PR TITLE
[DO NOT MERGE] Cross-compile pickling for scala 2.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ core/target/
 project/project/
 project/target/
 target/
+.idea

--- a/benchmark/SparkLR.scala
+++ b/benchmark/SparkLR.scala
@@ -3,6 +3,7 @@ import scala.pickling.Defaults._
 import scala.pickling.binary._
 import java.io._
 import scala.util.Random
+import scala.pickling.pickler.AllPicklers
 
 // taken from SparkLR:
 package spark.util { final class Vector(val elements: Array[Double]) extends Serializable { override def toString = s"""Vector(${elements.mkString(", ")})""" } }
@@ -11,7 +12,7 @@ import spark.util.Vector
 final case class DataPoint(x: Vector, y: Double) extends Serializable
 
 trait SparkLRBenchmark extends scala.pickling.testing.PicklingBenchmark {
-  val data = {
+  val data: ArrayBuffer[DataPoint] = {
     def generatePoint(i: Int) = {
       val y = if (i % 2 == 0) -1 else 1
       val x = {

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,8 @@ def commonSettings = Seq(
   resolvers += Resolver.sonatypeRepo("snapshots"),
   resolvers += Resolver.sonatypeRepo("releases"),
   scalacOptions ++= Seq("-feature"),
+  // TODO mitesh: REMOVE!
+  scalacOptions ++= Seq("-Xlog-implicits"),
   parallelExecution in Test := false, // hello, reflection sync!!
   publishMavenStyle in ThisBuild := true,
   publishArtifact in Test := false,

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._ // see project/Dependencies.scala
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 
-val buildVersion = "0.11.0-M2"
+val buildVersion = "0.11.0-aiq1"
 
 def commonSettings = Seq(
   version in ThisBuild := buildVersion,

--- a/core/src/main/scala-2.12/scala/pickling/tags/FastTypeTagMacros.scala
+++ b/core/src/main/scala-2.12/scala/pickling/tags/FastTypeTagMacros.scala
@@ -1,0 +1,60 @@
+package scala.pickling
+package tags
+
+import scala.language.experimental.macros
+
+/** Macros which take compiler types and turn them into
+ *  runtime string we can use to tag ADTs.
+ *  Additionally, these strings SHOULD be 100% compatible
+ *  with type tags generated from raw java reflection.
+ */
+trait FastTypeTagMacros extends Macro {
+
+  /** Extracts 'simple' types from complex ones.
+   *  here, simple means type constructors (and arguments).
+   *  This method will decompose these, while dropping anything fancy on the floor
+   *  (like existential types)
+   */
+  def extractSimpleTypes[T](t: c.Type)(handler: (String, List[c.Type]) => T): T = {
+    import c.universe._
+    import compat._
+    def handleType(t: c.Type): T =
+      t.normalize match {
+        case ExistentialType(tparams, TypeRef(pre, sym, targs))
+          if targs.nonEmpty && targs.forall(targ => tparams.contains(targ.typeSymbol)) =>
+            // rather than going down form List[_] => List we want to become List[Any],
+            // we are trying to make this match the java-reflection case (where it will be Any)
+            handleType(TypeRef(pre, sym, targs.map(_ => definitions.AnyTpe)))
+        // Note: This is incompatible with 2.10.x, where AnnotatedType takes 3 args
+        case AnnotatedType(_, raw) => handleType(raw)
+        case RefinedType(first :: tail, scope) => handleType(first)
+        // TODO - Special handling for inner-classes of classes
+        case TypeRef(pre, sym, targs) if pre.typeSymbol.isModuleClass =>
+          val name = sym.fullName + (if (sym.isModuleClass) ".type" else "")
+          handler(name, targs)
+      case _ => handler(t.toString, Nil)
+    }
+    handleType(t)
+  }
+  // TODO - Ideally this is uneeded, but for now there are a few places where we want the "string key" of
+  //        a fast type tag, so we duplicate the functionality of runtime in a compile-time method here.
+  def typeKey(t: c.Type): String = {
+    extractSimpleTypes(t) { (tcons, targs) =>
+      if (targs.isEmpty) tcons
+      else s"$tcons[${targs.map(typeKey).mkString(",")}]"
+    }
+  }
+
+  // TODO(joshuasuereth): This is may duplicate functionality with the `.tag` extension method on `Type`.
+  def impl[T: c.WeakTypeTag]: c.Tree = {
+    import c.universe._
+    import compat._
+    val T = weakTypeOf[T]
+    if (T.typeSymbol.isParameter)
+      c.abort(c.enclosingPosition, s"cannot generate FastTypeTag for type parameter $T, FastTypeTag can only be generated for concrete types")
+    extractSimpleTypes(T) { (tcons, targs) =>
+       val targSrcs = targs.map(t => q"_root_.scala.Predef.implicitly[_root_.scala.pickling.tags.FastTypeTag[${t}]]")
+       q"_root_.scala.pickling.tags.FastTypeTag[$T]($tcons, _root_.scala.List.apply(..$targSrcs))"
+    }
+  }
+}

--- a/core/src/main/scala/scala/pickling/binary/Util.scala
+++ b/core/src/main/scala/scala/pickling/binary/Util.scala
@@ -2,8 +2,16 @@ package scala.pickling.binary
 
 object UnsafeMemory {
   import sun.misc.Unsafe
-  private[pickling] val unsafe: Unsafe =
-  scala.concurrent.util.Unsafe.instance
+  private[pickling] val unsafeInstance = // use in place of Scala 2.11 usages of scala.concurrent.util.Unsafe.instance
+    classOf[sun.misc.Unsafe]
+      .getDeclaredFields
+      .filter(_.getType == classOf[sun.misc.Unsafe])
+      .headOption
+      .map { field =>
+        field.setAccessible(true)
+        field.get(null).asInstanceOf[sun.misc.Unsafe]
+      }
+      .getOrElse { throw new IllegalStateException("Can't find instance of sun.misc.Unsafe") }
   private[pickling] val byteArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Byte]])
   private[pickling] val shortArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Short]])
   private[pickling] val intArrayOffset: Long = unsafe.arrayBaseOffset(classOf[Array[Int]])

--- a/core/src/main/scala/scala/pickling/binary/Util.scala
+++ b/core/src/main/scala/scala/pickling/binary/Util.scala
@@ -2,7 +2,7 @@ package scala.pickling.binary
 
 object UnsafeMemory {
   import sun.misc.Unsafe
-  private[pickling] val unsafeInstance = // use in place of Scala 2.11 usages of scala.concurrent.util.Unsafe.instance
+  private[pickling] val unsafe: Unsafe = // use in place of Scala 2.11 usages of scala.concurrent.util.Unsafe.instance
     classOf[sun.misc.Unsafe]
       .getDeclaredFields
       .filter(_.getType == classOf[sun.misc.Unsafe])

--- a/core/src/main/scala/scala/pickling/runtime/Runtime.scala
+++ b/core/src/main/scala/scala/pickling/runtime/Runtime.scala
@@ -2,6 +2,7 @@ package scala.pickling
 package runtime
 
 import scala.pickling.PicklingErrors.BasePicklingException
+import scala.pickling.binary.UnsafeMemory
 import scala.pickling.internal._
 
 import scala.reflect.runtime.universe.Mirror
@@ -233,7 +234,7 @@ class InterpretedUnpicklerRuntime(val mirror: Mirror, typeTag: String)(implicit 
 
           // TODO: need to support modules and other special guys here
           // TODO: in principle, we could invoke a constructor here
-          val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+          val inst = UnsafeMemory.unsafe.allocateInstance(clazz)
           if (shouldBotherAboutSharing(tpe)) registerUnpicklee(inst, preregisterUnpicklee())
           val im = mirror.reflect(inst)
 
@@ -332,7 +333,7 @@ class ShareNothingInterpretedUnpicklerRuntime(val mirror: Mirror, typeTag: Strin
 
           // TODO: need to support modules and other special guys here
           // TODO: in principle, we could invoke a constructor here
-          val inst = scala.concurrent.util.Unsafe.instance.allocateInstance(clazz)
+          val inst = UnsafeMemory.unsafe.allocateInstance(clazz)
           val im = mirror.reflect(inst)
 
           //debug(s"pendingFields: ${pendingFields.size}")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.0-M15"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.0"
   lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.11.6"
-  lazy val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.2"
+  lazy val parserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
   lazy val macroParadise = "org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full
   lazy val quasiquotes = "org.scalamacros" %% "quasiquotes" % "2.0.1"
   lazy val kryoSerializers = "de.javakaffee" % "kryo-serializers" % "0.22"

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -2,8 +2,8 @@ import sbt._
 import Keys._
 
 object Util {
-  val buildScalaVersion = System.getProperty("scala.version", "2.11.8")
-  val buildScalaVersions = Seq("2.11.8", "2.10.6")
+  val buildScalaVersion = System.getProperty("scala.version", "2.12.14")
+  val buildScalaVersions = Seq("2.11.12", "2.12.14")
   val javaVersion       = System.getProperty("java.version")
 
   def loadCredentials(): List[Credentials] = {


### PR DESCRIPTION
Changing default to 2.12 and cross-compiling for 2.11. `FastTypeTagMacros.scala` is just copied from the 2.11 file.

